### PR TITLE
fix: Update command from analyse to analyze CY-2939

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
       run: echo "::set-env name=CLI_SCRIPT_PATH::${{ github.action_path }}/codacy-analysis-cli.sh"
     - name: "Download Codacy CLI script"
       shell: bash
-      run: wget -O - https://raw.githubusercontent.com/codacy/codacy-analysis-cli/3.6.0/bin/codacy-analysis-cli.sh > ${{ env.CLI_SCRIPT_PATH }}
+      run: wget -O - https://raw.githubusercontent.com/codacy/codacy-analysis-cli/4.0.0/bin/codacy-analysis-cli.sh > ${{ env.CLI_SCRIPT_PATH }}
     - name: "Change Codacy CLI script permissions"
       shell: bash
       run: chmod +x ${{ env.CLI_SCRIPT_PATH }}
@@ -64,7 +64,7 @@ runs:
       shell: bash
       run: >-
         ${{ env.CLI_SCRIPT_PATH }}
-        analyse
+        analyze
         $(if [ ${{ inputs.verbose }} = true ]; then echo "--verbose"; fi)
         $(if [ ${{ inputs.project-token }} ]; then echo "--project-token ${{ inputs.project-token }}"; fi)
         $(if [ ${{ inputs.codacy-api-base-url }} ]; then echo "--codacy-api-base-url ${{ inputs.codacy-api-base-url }}"; fi)


### PR DESCRIPTION
I noticed that the GitHub Action was failing (see the [full logs](https://pipelines.actions.githubusercontent.com/Xj0jzGyrtBdx8UfHGGMTPcXPzHHOUXHoRrLL6DzRPYU3jxEIdv/_apis/pipelines/1/runs/2296/signedlogcontent/3?urlExpires=2020-10-12T15%3A11%3A46.2748626Z&urlSigningMethod=HMACV1&urlSignature=7SsPojZHwOvTIKBqCgqJ%2BK%2BySWhxTX2IjNESmDNgwO0%3D)):

```
Run codacy/codacy-analysis-cli-action@master
  with:
    project-token: ***
    verbose: true
[...]
Status: Downloaded newer image for codacy/codacy-analysis-cli:stable
Command not found: analyse
Error: Process completed with exit code 1.
```

The conversion from the old command `analyse` to the new spelling `analyze` is only done on the [latest version 4.0.0](https://github.com/codacy/codacy-analysis-cli/blob/master/bin/codacy-analysis-cli.sh#L107-L111) of the `codacy-analysis-cli.sh`, but the GitHub Action downloaded the version 3.6.0.