### PR TITLE
clean: Edit section "Caveats"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,12 @@ Running the action with the default configurations will:
 
 Read the next section to learn how you can further configure this action.
 
-### Caveats
+## Extra configurations
 
-This action supports all [Codacy Analysis CLI configuration options](https://github.com/codacy/codacy-analysis-cli#commands-and-configuration), with the following exceptions:
+The Codacy GitHub Action is a wrapper for running the [Codacy Analysis CLI](https://github.com/codacy/codacy-analysis-cli) and supports the same parameters as the command `analyze`, with the following exceptions:
 
-- `--commit-uuid` -- **Not supported**. The action will always analyze the commit that triggered it.
-- `--api-token`, `--username`, and `--project` -- **Not supported**. Use [`--project-token`](https://github.com/codacy/codacy-analysis-cli#project-token) instead.
-
-The command `validate-configuration` is also **not supported**.
+- `--commit-uuid` (the action always analyzes the commit that triggered it)
+- `--api-token`, `--username`, and `--project` (use [`--project-token`](https://github.com/codacy/codacy-analysis-cli#project-token) instead)
 
 When using `--project-token` make sure that you use [GitHub security features](https://docs.github.com/en/actions/reference/encrypted-secrets)
 to avoid committing the secret token to your repository. For example, if you store your Codacy project


### PR DESCRIPTION
The limitations of not being able to use specific parameters of the Codacy Analysis CLI don't have a significant impact on the functionality of the GitHub Action. As such, we can mention them but we don't need to highlight them as being serious limitations.