### PR TITLE
fix: Remove references to coverage from API token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ To use the GitHub Action with Codacy integration:
 
 2.  Set up an API token to allow the GitHub Action to authenticate on Codacy:
 
-    -   **If you're setting up coverage for one repository**, [obtain a project API token](../codacy-api/api-tokens/#project-api-tokens) and store it as an [encrypted secret for your **repository**](https://docs.github.com/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) with the name `CODACY_PROJECT_TOKEN`.
-    -   **If you're setting up and automating coverage for multiple repositories**, [obtain an account API token](../codacy-api/api-tokens/#account-api-tokens) and store it as an [encrypted secret for your **organization**](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) with the name `CODACY_API_TOKEN`.
+    -   **If you're setting up one repository**, [obtain a project API token](../codacy-api/api-tokens/#project-api-tokens) and store it as an [encrypted secret for your **repository**](https://docs.github.com/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) with the name `CODACY_PROJECT_TOKEN`.
+    -   **If you're setting up multiple repositories**, [obtain an account API token](../codacy-api/api-tokens/#account-api-tokens) and store it as an [encrypted secret for your **organization**](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) with the name `CODACY_API_TOKEN`.
 
     > ⚠️ **Never write API tokens on your configuration files** and keep your API tokens well protected, as they grant owner permissions to your projects on Codacy.
 


### PR DESCRIPTION
Fixes a copy + paste mistake.