### PR TITLE
Cleans WD before Docker tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -232,6 +232,8 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.run-docker-tools }}" == "true" ]; then
+          git clean -f
+          git checkout .
           ${{ env.CLI_SCRIPT_PATH }} \
             analyze \
             $(if [ "${{ inputs.verbose }}" = "true" ]; then echo "--verbose"; fi) \

--- a/action.yml
+++ b/action.yml
@@ -232,8 +232,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.run-docker-tools }}" == "true" ]; then
-          git clean -f
-          git checkout .
+          git checkout -- go.mod
           ${{ env.CLI_SCRIPT_PATH }} \
             analyze \
             $(if [ "${{ inputs.verbose }}" = "true" ]; then echo "--verbose"; fi) \


### PR DESCRIPTION
This commit cleans up the working directory before running the Docker
tool(s). This is a requirement of the Codacy containerized tools.
So remove untracked files, restore tracked ones.

Fixes #55.
