### PR TITLE
fix: Reset go.mod files after listing packages CY-4272

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ runs:
           chmod +x /tmp/codacy-staticcheck
           cd -
 
-          find . -type f -name go.mod -exec bash -c 'cd $(dirname $1); PKGS=$(go list ./...); /tmp/staticcheck/staticcheck -f json $PKGS' _ {} \; > /tmp/staticcheck-out.json
+          find . -type f -name go.mod -exec bash -c 'cd $(dirname $1); PKGS=$(go list ./...); git checkout $1; /tmp/staticcheck/staticcheck -f json $PKGS' _ {} \; > /tmp/staticcheck-out.json
           /tmp/codacy-staticcheck < /tmp/staticcheck-out.json > /tmp/codacy-out.json
           if [ ${{ inputs.upload }} = true ]; then
             curl -XPOST -L -H "$CURL_CODACY_AUTH_AUTHENTICATION" \


### PR DESCRIPTION
The command `go list` was changing the `go.mod` file, and then the CLI execution failed because the repository had uncommitted changes.
This will reset the go.mod if we for some reason change it.