### PR TITLE
action: prevent globbing with double quotes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,11 +85,11 @@ runs:
     - name: "Set Global Variables"
       shell: bash
       run: |
-        echo "CODACY_BASE_URL_OR_DEFAULT=$(if [ ${{ inputs.codacy-api-base-url }} ]; then echo "${{ inputs.codacy-api-base-url }}"; else echo "https://api.codacy.com"; fi)" >> $GITHUB_ENV
-        echo "OWNER_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 1)" >> $GITHUB_ENV
-        echo "REPOSITORY_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_ENV
-        echo "ORGANIZATION_PROVIDER=$(if [ "$GITHUB_SERVER_URL" == "https://github.com" ]; then echo "gh"; else echo "ghe"; fi)" >> $GITHUB_ENV
-        echo "COMMIT_SHA=$(if [ ${{ github.event_name }} == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${{ github.sha }}"; fi)" >> $GITHUB_ENV
+        echo "CODACY_BASE_URL_OR_DEFAULT=$(if [ -n "${{ inputs.codacy-api-base-url }}" ]; then echo "${{ inputs.codacy-api-base-url }}"; else echo "https://api.codacy.com"; fi)" >> "$GITHUB_ENV"
+        echo "OWNER_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d '/' -f 1)" >> "$GITHUB_ENV"
+        echo "REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d '/' -f 2)" >> "$GITHUB_ENV"
+        echo "ORGANIZATION_PROVIDER=$(if [ "$GITHUB_SERVER_URL" == "https://github.com" ]; then echo "gh"; else echo "ghe"; fi)" >> "$GITHUB_ENV"
+        echo "COMMIT_SHA=$(if [ "${{ github.event_name }}" == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${{ github.sha }}"; fi)" >> "$GITHUB_ENV"
 
     - name: "Prepare curl authentication header"
       shell: bash
@@ -98,7 +98,7 @@ runs:
           echo "CURL_CODACY_AUTH_AUTHENTICATION=api-token: ${{ inputs.api-token }}" >> $GITHUB_ENV
         elif [ -n "${{ inputs.project-token }}" ]; then
           echo "CURL_CODACY_AUTH_AUTHENTICATION=project-token: ${{ inputs.project-token }}" >> $GITHUB_ENV
-        elif [ ${{ inputs.upload }} = true ]; then
+        elif [ "${{ inputs.upload }}" == "true" ]; then
           echo "At least one authentication method is required to upload results."
           exit 1
         fi
@@ -121,7 +121,7 @@ runs:
 
           /tmp/bin/gosec -no-fail -fmt json -log /tmp/log.txt ./... > /tmp/gosec-out.json
           /tmp/codacy-gosec < /tmp/gosec-out.json > /tmp/codacy-out.json
-          if [ ${{ inputs.upload }} = true ]; then
+          if [ "${{ inputs.upload }}" == "true" ]; then
             curl -XPOST -L -H "$CURL_CODACY_AUTH_AUTHENTICATION" \
               -H "Content-type: application/json" --data-binary @/tmp/codacy-out.json \
               "${CODACY_BASE_URL_OR_DEFAULT}/2.0/$ORGANIZATION_PROVIDER/$OWNER_NAME/$REPOSITORY_NAME/commit/$COMMIT_SHA/issuesRemoteResults"
@@ -154,7 +154,7 @@ runs:
 
           find . -type f -name go.mod -exec bash -c 'cd $(dirname $1); cp $1 $1.codacy.bak; PKGS=$(go list ./...); /tmp/staticcheck/staticcheck -f json $PKGS; mv $1.codacy.bak $1' _ {} \; > /tmp/staticcheck-out.json
           /tmp/codacy-staticcheck < /tmp/staticcheck-out.json > /tmp/codacy-out.json
-          if [ ${{ inputs.upload }} = true ]; then
+          if [ "${{ inputs.upload }}" == "true" ]; then
             curl -XPOST -L -H "$CURL_CODACY_AUTH_AUTHENTICATION" \
               -H "Content-type: application/json" --data-binary @/tmp/codacy-out.json \
               "${CODACY_BASE_URL_OR_DEFAULT}/2.0/$ORGANIZATION_PROVIDER/$OWNER_NAME/$REPOSITORY_NAME/commit/$COMMIT_SHA/issuesRemoteResults"
@@ -180,7 +180,7 @@ runs:
           cd -
 
           /tmp/codacy-clang-tidy < "${{ inputs.clang-tidy-output }}" > /tmp/codacy-out.json
-          if [ ${{ inputs.upload }} = true ]; then
+          if [ "${{ inputs.upload }}" == "true" ]; then
             curl -XPOST -L -H "$CURL_CODACY_AUTH_AUTHENTICATION" \
               -H "Content-type: application/json" --data-binary @/tmp/codacy-out.json \
               "${CODACY_BASE_URL_OR_DEFAULT}/2.0/$ORGANIZATION_PROVIDER/$OWNER_NAME/$REPOSITORY_NAME/commit/$COMMIT_SHA/issuesRemoteResults"
@@ -206,7 +206,7 @@ runs:
           cd -
 
           /tmp/codacy-faux-pas < "${{ inputs.faux-pas-output }}" > /tmp/codacy-out.json
-          if [ ${{ inputs.upload }} = true ]; then
+          if [ "${{ inputs.upload }}" == "true" ]; then
             curl -XPOST -L -H "$CURL_CODACY_AUTH_AUTHENTICATION" \
               -H "Content-type: application/json" --data-binary @/tmp/codacy-out.json \
               "${CODACY_BASE_URL_OR_DEFAULT}/2.0/$ORGANIZATION_PROVIDER/$OWNER_NAME/$REPOSITORY_NAME/commit/$COMMIT_SHA/issuesRemoteResults"
@@ -228,7 +228,7 @@ runs:
       run: wget -O - https://raw.githubusercontent.com/codacy/codacy-analysis-cli/${{ env.CODACY_ANALYSIS_CLI_VERSION }}/bin/codacy-analysis-cli.sh > ${{ env.CLI_SCRIPT_PATH }}
     - name: "Change Codacy CLI script permissions"
       shell: bash
-      run: chmod +x ${{ env.CLI_SCRIPT_PATH }}
+      run: chmod +x "${{ env.CLI_SCRIPT_PATH }}"
     - name: "Run Codacy CLI"
       shell: bash
       run: |
@@ -237,7 +237,7 @@ runs:
             analyze \
             --skip-commit-uuid-validation \
             --commit-uuid $COMMIT_SHA \
-            $(if [ "${{ inputs.verbose }}" = "true" ]; then echo "--verbose"; fi) \
+            $(if [ "${{ inputs.verbose }}" == "true" ]; then echo "--verbose"; fi) \
             $(if [ -n "${{ inputs.project-token }}" ]; then echo "--project-token ${{ inputs.project-token }}"; fi) \
             $(if [ -n "${{ inputs.api-token }}" ]; then echo "--api-token ${{ inputs.api-token }} --username $OWNER_NAME --project $REPOSITORY_NAME --provider $ORGANIZATION_PROVIDER"; fi) \
             $(if [ -n "${{ inputs.codacy-api-base-url }}" ]; then echo "--codacy-api-base-url ${{ inputs.codacy-api-base-url }}"; fi) \
@@ -248,11 +248,11 @@ runs:
             $(if [ -n "${{ inputs.max-allowed-issues }}" ]; then echo "--max-allowed-issues ${{ inputs.max-allowed-issues }}"; fi) \
             $(if [ -n "${{ inputs.tool }}" ]; then echo "--tool ${{ inputs.tool }}"; fi) \
             $(if [ -n "${{ inputs.tool-timeout }}" ]; then echo "--tool-timeout ${{ inputs.tool-timeout }}"; fi) \
-            $(if [ "${{ inputs.upload }}" = "true" ]; then echo "--upload"; fi) \
-            $(if [ "${{ inputs.fail-if-incomplete }}" = "true" ]; then echo "--fail-if-incomplete"; fi) \
-            $(if [ "${{ inputs.allow-network }}" = "true" ]; then echo "--allow-network"; fi) \
-            $(if [ "${{ inputs.force-file-permissions }}" = "true" ]; then echo "--force-file-permissions"; fi) \
-            $(if [ "${{ inputs.gh-code-scanning-compat }}" = "true" ]; then echo "--gh-code-scanning-compat"; fi)
+            $(if [ "${{ inputs.upload }}" == "true" ]; then echo "--upload"; fi) \
+            $(if [ "${{ inputs.fail-if-incomplete }}" == "true" ]; then echo "--fail-if-incomplete"; fi) \
+            $(if [ "${{ inputs.allow-network }}" == "true" ]; then echo "--allow-network"; fi) \
+            $(if [ "${{ inputs.force-file-permissions }}" == "true" ]; then echo "--force-file-permissions"; fi) \
+            $(if [ "${{ inputs.gh-code-scanning-compat }}" == "true" ]; then echo "--gh-code-scanning-compat"; fi)
         else
           echo "Skipping docker tools"
         fi
@@ -260,7 +260,7 @@ runs:
     - name: "Let Codacy know it can start processing the analysis results"
       shell: bash
       run: |
-        if [ ${{ inputs.upload }} = true ]; then
+        if [ "${{ inputs.upload }}" == "true" ]; then
           echo "Uploading results for $ORGANIZATION_PROVIDER/$OWNER_NAME/$REPOSITORY_NAME commit $COMMIT_SHA"
           curl -XPOST -L -H "$CURL_CODACY_AUTH_AUTHENTICATION" \
             -H "Content-type: application/json" \

--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
         echo "ORGANIZATION_PROVIDER=$(if [ "$GITHUB_SERVER_URL" == "https://github.com" ]; then echo "gh"; else echo "ghe"; fi)" >> "$GITHUB_ENV"
         echo "COMMIT_SHA=$(if [ "${{ github.event_name }}" == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${{ github.sha }}"; fi)" >> "$GITHUB_ENV"
         if [ -n "${{ inputs.skip-container-engine-check }}" ]; then
-          echo "SKIP_CONTAINER_ENGINE_CHECK=${{ inputs.skip-container-engine-check }}" >> $GITHUB_ENV
+          echo "SKIP_CONTAINER_ENGINE_CHECK=${{ inputs.skip-container-engine-check }}" >> "$GITHUB_ENV"
         fi
 
     - name: "Prepare curl authentication header"


### PR DESCRIPTION
This patch adds double quotes on variables to prevent globbing and prevent evaluation errors such as:

    line 1: [: =: unary operator expected

It also add consistency on bash string equality comparison by using `==`
operator instead of `=`.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Since this is behaving "good" by accident, please double check if this doesn't break any specific use-case of this action. I recommend changing this to standalone scripts and passing GitHub variables by argument and parse them using something like POSIX getopt. See https://man7.org/linux/man-pages/man1/getopts.1p.html