### PR TITLE
doc: Improve description for upload-batch-size

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
     description: "Upload analysis results to Codacy"
   upload-batch-size:
     required: false
-    description: "Size (in number of results) of result batches to be uploaded to Codacy"
+    description: "Maximum number of results in each batch to upload to Codacy"
   fail-if-incomplete:
     required: false
     description: "Fail the analysis if any tool fails to run"


### PR DESCRIPTION
Initially, I thought that the batch size was specified in bytes, but since it's the actual number of results in each batch, the description can be more straightforward.

I also opened https://github.com/codacy/codacy-analysis-cli/pull/443 to update the description on the Codacy Analysis CLI.