### PR TITLE
feature: Introduce new versioning scheme `vX.X.X`

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -1,0 +1,14 @@
+name: publish-action
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    name: Release GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release GitHub Actions
+        uses: technote-space/release-github-actions@v4


### PR DESCRIPTION
Publish `vMAJOR` and `vMAJOR.MINOR` tags as well on every commit
For example, when publishing `v4.1.0`, the action will be publishing `v4` and `v4.1`