### PR TITLE
bump cli version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -223,7 +223,7 @@ runs:
 
     - name: "Set Codacy CLI version"
       shell: bash
-      run: echo "CODACY_ANALYSIS_CLI_VERSION=7.6.4" >> $GITHUB_ENV
+      run: echo "CODACY_ANALYSIS_CLI_VERSION=7.9.1" >> $GITHUB_ENV
     - name: "Set script path environment variable"
       shell: bash
       run: echo "CLI_SCRIPT_PATH=${{ github.action_path }}/codacy-analysis-cli.sh" >> $GITHUB_ENV


### PR DESCRIPTION
for some reason we are pinning this version in the code and were not aware. 

Bumping to the latest for now, we should look into this as it causes the CLI version to be frozen (most likely without need)